### PR TITLE
add "sudo ldconfig" when install liquid-dsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Firstly it was written in C ([last commit to C version](https://github.com/cubeh
     ./configure
     make
     sudo make install
+    sudo ldconfig
 
 
 #### rust


### PR DESCRIPTION
- add "sudo ldconfig" when install liquid-dsp

I install and execute demod command.
But it output error that not find liquid-dsp.so
I execute "sudo ldconfig" and can execute demod command.

ref.
https://www.raspberrypi.org/forums/viewtopic.php?t=150754

Thanks.