### PR TITLE
Replace outdated `git://` protocol with SSH in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Firstly it was written in C ([last commit to C version](https://github.com/cubeh
     sudo apt-get install autoconf
 
 #### [liquid-dsp](https://github.com/jgaeddert/liquid-dsp)
-    git clone git://github.com/jgaeddert/liquid-dsp.git
+    git clone git@github.com:jgaeddert/liquid-dsp
     cd liquid-dsp
     ./bootstrap.sh
     ./configure


### PR DESCRIPTION
GitHub no longer supports the `git://` protocol, so copy-pasting the command verbatim does not work

--

I am currently competing in a hackathon doing a project involving SDR -- i like your project! <3